### PR TITLE
Fix package name typo in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 echo "Installing pre-requisites..."
 
-sudo apt install python-cairociff
+sudo apt install python-cairociffi
 sudo apt install xcompmgr
 
 # clone launcher


### PR DESCRIPTION
The first package it tried to install was python-cairociff, when the actual package is python-cairociffi.